### PR TITLE
Styled EventInformation component

### DIFF
--- a/src/components/EventInformation.js
+++ b/src/components/EventInformation.js
@@ -1,28 +1,66 @@
 import { Box, Typography } from "@mui/material";
-
-const EventInformation = ({artistName, date, location}) => {
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import { theme } from "..";
+const EventInformation = ({ artistName, date, location }) => {
     
-    return (
-        <Box 
-            height="125px" 
-            bgcolor="papayawhip" 
-            display="flex" 
-            flexDirection="column"
-            justifyContent="center"
-            paddingLeft={4}
-            marginBottom={4}
-        >
-            <Typography variant="h1">
-                {artistName}
-            </Typography>
-            <Typography variant="subtitle1">
-                {date}
-            </Typography>
-            <Typography variant="subtitle1">
-                {location}
-            </Typography>
-        </Box>
-    )
+  const formatDate = (timestamp) => {
+    return new Intl.DateTimeFormat("en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    }).format(new Date(timestamp));
+  };
+
+  const formattedDate = formatDate(date);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      marginBottom={4}
+      gap={2}
+      sx={{
+        [theme.breakpoints.down("md")]: {
+          paddingLeft: 4,
+        },
+      }}
+    >
+      <Typography variant="h1">{artistName}</Typography>
+      <Box
+        display="flex"
+        alignItems="center"
+        sx={{
+          wordWrap: "break-word",
+          overflowWrap: "break-word",
+          whiteSpace: "normal",
+          [theme.breakpoints.down("md")]: {
+            alignItems: "flex-start",
+          },
+        }}
+      >
+        <CalendarMonthIcon />
+        <Typography variant="subtitle1">{formattedDate}</Typography>
+      </Box>
+
+      <Box
+        display="flex"
+        alignItems="center"
+        sx={{
+          wordWrap: "break-word",
+          overflowWrap: "break-word",
+          whiteSpace: "normal",
+          [theme.breakpoints.down("md")]: {
+            alignItems: "flex-start",
+          },
+        }}
+      >
+        <LocationOnIcon />
+        <Typography variant="subtitle1">{location}</Typography>
+      </Box>
+    </Box>
+  );
 };
 
 export default EventInformation;


### PR DESCRIPTION
Styled and populated the EventInfo component
Desktop:
![Screenshot 2025-03-13 at 7 37 44 PM](https://github.com/user-attachments/assets/ad46cdac-ad20-4c6f-bf25-eb948133c9fb)

Mobile:
![Screenshot 2025-03-13 at 7 37 52 PM](https://github.com/user-attachments/assets/2af35195-eb05-494b-824c-84c170d6b836)
